### PR TITLE
Feature/optional external native binary

### DIFF
--- a/libdeflate-java-core/build.gradle.kts
+++ b/libdeflate-java-core/build.gradle.kts
@@ -62,8 +62,10 @@ task("compileNatives") {
 }
 
 sourceSets {
-    main {
-        resources.srcDir(Paths.get(project.rootDir.toString(), "tmp", "compiled"))
+    if (!project.hasProperty("only_interface")) {
+        main {
+            resources.srcDir(Paths.get(project.rootDir.toString(), "tmp", "compiled"))
+        }
     }
 }
 

--- a/libdeflate-java-core/src/main/java/me/steinborn/libdeflate/Libdeflate.java
+++ b/libdeflate-java-core/src/main/java/me/steinborn/libdeflate/Libdeflate.java
@@ -1,9 +1,11 @@
 package me.steinborn.libdeflate;
 
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Locale;
 
@@ -38,7 +40,13 @@ public class Libdeflate {
         try {
             InputStream nativeLib = Libdeflate.class.getResourceAsStream(path);
             if (nativeLib == null) {
-                throw new IllegalStateException("Native library " + path + " not found.");
+                // in case the user is trying to load native library from an absolute path
+                Path libPath = Paths.get(path);
+                if (Files.exists(libPath) && Files.isRegularFile(libPath)) {
+                    nativeLib = new FileInputStream(path);
+                } else {
+                    throw new IllegalStateException("Native library " + path + " not found.");
+                }
             }
 
             Path tempFile = createTemporaryNativeFilename(path.substring(path.lastIndexOf('.')));

--- a/libdeflate-java-core/src/main/java/me/steinborn/libdeflate/Libdeflate.java
+++ b/libdeflate-java-core/src/main/java/me/steinborn/libdeflate/Libdeflate.java
@@ -11,6 +11,7 @@ public class Libdeflate {
     private static final String OS_SYSTEM_PROPERTY = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
     private static final String OS;
     private static final String ARCH = System.getProperty("os.arch").toLowerCase(Locale.ENGLISH);
+    private static final String NATIVE_LIB_PATH = System.getProperty("libdeflate_jni_path", "");
     private static Throwable unavailabilityCause;
 
     static {
@@ -22,10 +23,10 @@ public class Libdeflate {
             OS = OS_SYSTEM_PROPERTY;
         }
 
-        String path = determineLoadPath();
+        String path = NATIVE_LIB_PATH.isEmpty() ? "/" + determineLoadPath() : NATIVE_LIB_PATH;
 
         try {
-            copyAndLoadNative("/" + path);
+            copyAndLoadNative(path);
             // It is available
             unavailabilityCause = null;
         } catch (Throwable e) {


### PR DESCRIPTION
@astei I recently found this repo very helpful to my work, and would like to make some changes regarding the build and look up of native binary in the run time.

Basically the main motivation is to allow user to package interface Java code in the jar (optionally), while building the native library separately. The benefits is so that one can package once for the Java code, and simply link to the locally complied native binary. For example, if you need to run the code on multiple platforms with various CPU architecture, building on the target would be convenient and help achieve best possible performance